### PR TITLE
Fixed #5, add manifest.js and verdor.js in build script

### DIFF
--- a/template/core/webpack.base.js
+++ b/template/core/webpack.base.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const webpack = require('webpack')
 const ChromeReloadPlugin  = require('wcer')
-const {cssLoaders, htmlPage} = require('./tools')
+const { cssLoaders } = require('./tools')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 let resolve = dir => path.join(__dirname, '..', 'src', dir)
@@ -10,7 +10,7 @@ module.exports = {
     tab: resolve('./tab'),
     popup: resolve('./popup'),
     options: resolve('./options'),
-    content: resolve('./content'), 
+    content: resolve('./content'),
     devtools: resolve('./devtools'),
     background: resolve('./backend'),
     panel: resolve('./devtools/panel'),
@@ -90,12 +90,6 @@ module.exports = {
     ]
   },
   plugins: [
-    htmlPage('home', 'app', ['tab']),
-    htmlPage('popup', 'popup', ['popup']),
-    htmlPage('panel', 'panel', ['panel']),
-    htmlPage('devtools', 'devtools', ['devtools']),
-    htmlPage('options', 'options', ['options']),
-    htmlPage('background', 'background', ['background']),
     new CopyWebpackPlugin([{ from: path.join(__dirname, '..', 'static') }]),
     new ChromeReloadPlugin({
       port: 9090,

--- a/template/core/webpack.dev.js
+++ b/template/core/webpack.dev.js
@@ -3,7 +3,7 @@ const webpack = require('webpack')
 const merge = require('webpack-merge')
 const baseWebpack = require('./webpack.base')
 const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
-const {styleLoaders} = require('./tools')
+const { styleLoaders, htmlPage } = require('./tools')
 module.exports = merge(baseWebpack, {
   // cheap-module-eval-source-map быстрее для разработки
   watch: true,
@@ -12,6 +12,12 @@ module.exports = merge(baseWebpack, {
   },
   devtool: '#cheap-module-eval-source-map',
   plugins: [
+    htmlPage('home', 'app', ['tab']),
+    htmlPage('popup', 'popup', ['popup']),
+    htmlPage('panel', 'panel', ['panel']),
+    htmlPage('devtools', 'devtools', ['devtools']),
+    htmlPage('options', 'options', ['options']),
+    htmlPage('background', 'background', ['background']),
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"development"'

--- a/template/core/webpack.prod.js
+++ b/template/core/webpack.prod.js
@@ -6,13 +6,19 @@ const baseWebpack = require('./webpack.base')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
-const {styleLoaders} = require('./tools')
+const { styleLoaders, htmlPage } = require('./tools')
 module.exports = merge(baseWebpack, {
   devtool: '#cheap-module-eval-source-map',
   module: {
     rules: styleLoaders({ extract: true, sourceMap: true })
   },
   plugins: [
+    htmlPage('home', 'app', ['manifest', 'vendor', 'tab']),
+    htmlPage('popup', 'popup', ['manifest', 'vendor', 'popup']),
+    htmlPage('panel', 'panel', ['manifest', 'vendor', 'panel']),
+    htmlPage('devtools', 'devtools', ['manifest', 'vendor', 'devtools']),
+    htmlPage('options', 'options', ['manifest', 'vendor', 'options']),
+    htmlPage('background', 'background', ['manifest', 'vendor', 'background']),
     new CleanWebpackPlugin(['build/*.*']),
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.DefinePlugin({


### PR DESCRIPTION
CommonsChunkPlugin will cut runtime out into manifest.js, and move 3th-part code into verdor.js. So need include them in every pages.